### PR TITLE
Reconnect to Broker After Connection Failure

### DIFF
--- a/examples/subscriber.py
+++ b/examples/subscriber.py
@@ -19,7 +19,12 @@ def handle_test_message(topic, message):
 
 
 connection = Pigeon(
-    "Subscriber", host=host, port=port, logger=logger, load_topics=False, connection_timeout=None,
+    "Subscriber",
+    host=host,
+    port=port,
+    logger=logger,
+    load_topics=False,
+    connection_timeout=None,
 )
 connection.register_topic("test", TestMsg)
 connection.connect(username="admin", password="password")

--- a/examples/subscriber.py
+++ b/examples/subscriber.py
@@ -19,7 +19,7 @@ def handle_test_message(topic, message):
 
 
 connection = Pigeon(
-    "Subscriber", host=host, port=port, logger=logger, load_topics=False
+    "Subscriber", host=host, port=port, logger=logger, load_topics=False, connection_timeout=None,
 )
 connection.register_topic("test", TestMsg)
 connection.connect(username="admin", password="password")

--- a/pigeon/__main__.py
+++ b/pigeon/__main__.py
@@ -3,14 +3,20 @@ import argparse
 import yaml
 from functools import partial
 import json
+from inspect import getsource
+from textwrap import indent
+from os import environ
 
 
 class Listener:
-    def __init__(self, disp_headers, record):
+    def __init__(self, disp_headers, record=False, rate=False, quiet=False):
         self.message_received = False
         self.disp_headers = disp_headers
         self.record = record
+        self.rate = rate
+        self.quiet = quiet
         self.messages = []
+        self.last_timestamp = None
 
     def callback(self, msg, topic, headers):
         if self.record:
@@ -21,13 +27,24 @@ class Listener:
                     "headers": headers,
                 }
             )
-        else:
+        if not self.quiet:
             print(f"Recieved message on topic '{topic}':")
             print(msg)
             if self.disp_headers:
                 print("With headers:")
                 for key, val in headers.items():
                     print(f"{key}={val}")
+        if self.rate:
+            if self.last_timestamp is not None:
+                try:
+                    rate = 1000 / (
+                        int(headers.get("sent_at")) - int(self.last_timestamp)
+                    )
+                    print(f"Rate: {rate} Hz")
+                except ValueError as e:
+                    print("Could not parse timestamp:")
+                    print(e)
+            self.last_timestamp = headers.get("sent_at")
         self.message_received = True
 
     def write(self, path):
@@ -40,21 +57,22 @@ def main():
     parser.add_argument(
         "--host",
         type=str,
-        default="127.0.0.1",
-        help="The message broker to connect to.",
+        help="The message broker to connect to. Defaults to the PIGEON_HOST environment variable if set, otherwise 127.0.0.1.",
     )
     parser.add_argument(
-        "--port", type=int, default=61616, help="The port to use for the connection."
+        "--port",
+        type=int,
+        help="The port to use for the connection. Defaults to the PIGEON_PORT environment variable if set, otherwise 61616.",
     )
     parser.add_argument(
         "--username",
         type=str,
-        help="The username to use when connecting to the STOMP server.",
+        help="The username to use when connecting to the STOMP server. The environment variable PIGEON_USERNAME is used if set.",
     )
     parser.add_argument(
         "--password",
         type=str,
-        help="The password to use when connecting to the STOMP server.",
+        help="The password to use when connecting to the STOMP server. The environment variable PIGEON_PASSWORD is used if set.",
     )
     parser.add_argument(
         "-p", "--publish", type=str, help="The topic to publish a message to."
@@ -77,47 +95,81 @@ def main():
         "-r", "--record", type=str, help="Write received messages to a JSON file."
     )
     parser.add_argument(
-        "--one", action="store_true", help="Exit after receiving one message."
+        "--rate",
+        action="store_true",
+        help="Display the rate at which messages are received.",
+    )
+    parser.add_argument(
+        "-1", "--one", action="store_true", help="Exit after receiving one message."
     )
     parser.add_argument(
         "-l", "--list", action="store_true", help="List registered topics and exit."
     )
     parser.add_argument(
+        "--show",
+        action="append",
+        default=[],
+        type=str,
+        help="Show the message definition of the specified topic.",
+    )
+    parser.add_argument(
         "--headers", action="store_true", help="Display headers of received messages."
+    )
+    parser.add_argument(
+        "-q", "--quiet", action="store_true", help="Don't display incoming messages."
     )
 
     args = parser.parse_args()
 
+    connection = Pigeon(
+        "CLI",
+        environ.get("PIGEON_HOST", "127.0.0.1") if args.host is None else args.host,
+        environ.get("PIGEON_PORT", 61616) if args.port is None else args.port,
+    )
+
     if args.list:
-        connection = Pigeon("CLI")
         for topic in connection._topics:
             print(topic)
-        return
+
+    for topic in args.show:
+        if topic not in connection._topics:
+            print(f"Topic {topic} not defined!")
+            continue
+        print(f"{topic}:")
+        print(indent(getsource(connection._topics[topic]), "    "))
 
     if args.publish is None and args.subscribe is None and not args.all:
         print("No action specified.")
-        return
+        exit(1)
 
     if args.publish and args.data is None:
         print("Must also specify data to publish.")
-        return
+        exit(1)
 
     if args.data and args.publish is None:
         print("Must also specify topic to publish data to.")
-        return
+        exit(1)
 
     if args.record is not None and not (args.subscribe or args.all):
         print("No subscriptions to record.")
-        return
+        exit(1)
 
-    connection = Pigeon("CLI", args.host, args.port)
-    connection.connect(args.username, args.password)
+    if args.publish or args.subscribe or args.all:
+        connection.connect(
+            environ.get("PIGEON_USERNAME") if args.username is None else args.username,
+            environ.get("PIGEON_PASSWORD") if args.password is None else args.password,
+        )
 
     if args.publish:
         connection.send(args.publish, **yaml.safe_load(args.data))
 
     if args.subscribe or args.all:
-        listener = Listener(args.headers, args.record is not None)
+        listener = Listener(
+            args.headers,
+            record=args.record is not None,
+            rate=args.rate,
+            quiet=args.quiet,
+        )
 
     if args.all:
         connection.subscribe_all(listener.callback)
@@ -130,9 +182,10 @@ def main():
             while not (args.one and listener.message_received):
                 pass
         except KeyboardInterrupt:
+            print("exiting")
+        finally:
             if args.record is not None:
                 listener.write(args.record)
-            print("exiting")
     exit(0)
 
 

--- a/pigeon/client.py
+++ b/pigeon/client.py
@@ -231,7 +231,7 @@ class Pigeon:
         else:
             Thread(
                 target=self._run_callback,
-                args=(message_data, topic, message_frame.headers),
+                args=(callback, message_data, topic, message_frame.headers),
             ).start()
 
     def _run_callback(self, callback, message_data, topic, headers):

--- a/pigeon/client.py
+++ b/pigeon/client.py
@@ -19,6 +19,7 @@ from .utils import (
     call_with_correct_args,
     setup_zipkin_transport,
 )
+from threading import Thread
 
 
 def get_str_time_ms():
@@ -49,6 +50,7 @@ class Pigeon:
         load_topics: bool = True,
         create_zipkin_spans: bool = True,
         send_zipkin_headers: bool = True,
+        spawn_threads: bool = False,
     ):
         """
         Args:
@@ -62,9 +64,11 @@ class Pigeon:
             create_zipkin_spans: If true, and required environment variables are present,
                 configure Zipkin transport and create new spans for every received message.
             send_zipkin_headers: If true, attempt to send Zipkin span propogation headers.
+            spawn_threads: If true, create a new thread for every message received.
 
         """
         self._service = service
+        self._spawn_threads = spawn_threads
         self._connection = stomp.Connection12([(host, port)], heartbeats=(10000, 10000))
         self._topics = {}
         self._hashes = {}
@@ -222,14 +226,18 @@ class Pigeon:
                 f"No callback for message received on topic '{topic}'."
             )
             return
+        if not self._spawn_threads:
+            self._run_callback(callback, message_data, topic, message_frame.headers)
+        else:
+            Thread(
+                target=self._run_callback,
+                args=(message_data, topic, message_frame.headers),
+            ).start()
+
+    def _run_callback(self, callback, message_data, topic, headers):
         try:
-            self.with_zipkin_span_from_headers(
-                message_frame.headers,
-                call_with_correct_args,
-                callback,
-                message_data,
-                topic,
-                message_frame.headers,
+            self._with_zipkin_span_from_headers(
+                headers, call_with_correct_args, callback, message_data, topic, headers
             )
         except exceptions.SignatureException as e:
             self._logger.warning(
@@ -240,7 +248,7 @@ class Pigeon:
                 f"Callback for topic '{topic}' failed with error:", exc_info=True
             )
 
-    def with_zipkin_span_from_headers(self, headers, function, *args, **kwargs):
+    def _with_zipkin_span_from_headers(self, headers, function, *args, **kwargs):
         if (
             self._zipkin_transport is None
             or (zipkin_attrs := extract_zipkin_attrs_from_headers(headers)) is None

--- a/pigeon/client.py
+++ b/pigeon/client.py
@@ -52,6 +52,7 @@ class Pigeon:
         send_zipkin_headers: bool = True,
         spawn_threads: bool = False,
         connection_timeout: float = 10,
+        send_timeout: float = 0,
     ):
         """
         Args:
@@ -68,6 +69,8 @@ class Pigeon:
             spawn_threads: If true, create a new thread for every message received.
             connection_timeout: The number of seconds to attempt to connect to the broker.
                 Set to None to attempt to connect indefinitely.
+            send_timeout: The number of seconds to attempt to send a message, or None to
+                try indefinitely.
 
         """
         self._service = service
@@ -75,6 +78,7 @@ class Pigeon:
         self._connection = stomp.Connection12([(host, port)], heartbeats=(10000, 10000))
         self._connected = False
         self._connection_timeout = connection_timeout
+        self._send_timeout = send_timeout
         self._username = None
         self._password = None
         self._topics = {}
@@ -83,7 +87,7 @@ class Pigeon:
             self._load_topics()
         self._callbacks: Dict[str, Callable] = {}
         self._connection.set_listener(
-            "listener", TEMCommsListener(self._handle_message, self._handle_reconnect)
+            "listener", PigeonListener(self._handle_message, self._handle_reconnect)
         )
         self._logger = logger if logger is not None else logging.getLogger(__name__)
 
@@ -144,6 +148,7 @@ class Pigeon:
         self,
         username: str = None,
         password: str = None,
+        announce: bool = True
     ):
         """
         Connects to the STOMP server using the provided username and password.
@@ -151,7 +156,8 @@ class Pigeon:
         Args:
             username (str, optional): The username to authenticate with. Defaults to None.
             password (str, optional): The password to authenticate with. Defaults to None.
-            retry_limit (int, optional): Number of times to attempt connection
+            announce (bool, optional): If true will send a message through the broker that
+                it has connected.
 
         Raises:
             stomp.exception.ConnectFailedException: If the connection to the server fails.
@@ -187,27 +193,27 @@ class Pigeon:
         if "&_request_state" not in self._callbacks:
             self.subscribe("&_request_state", self._update_state)
 
-        self._announce()
+        if announce:
+            self._announce()
 
-    def send(self, topic: str, **data):
+    def send(self, topic: str, timeout=..., **data):
         """
         Sends data to the specified topic.
 
         Args:
             topic (str): The topic to send the data to.
+            timeout (float, None): The length of time to attempt to send the
+                message, or None to try indefinitely. If set to ..., the default,
+                the send_timeout value from the client constructor will be used.
             **data: Keyword arguments representing the data to be sent.
 
         Raises:
             exceptions.NoSuchTopicException: If the specified topic is not defined.
+            TimeoutError: If the message was not able to be sent within the required
+                timeframe.
         """
-        if not self._connected:
-            self._logger.warning(
-                f"Not connected to broker! Unable to send message on topic {topic}."
-            )
-            return
         self._ensure_topic_exists(topic)
         message = self._topics[topic](**data)
-
         headers = dict(
             source=self._name,
             service=self._service,
@@ -218,10 +224,27 @@ class Pigeon:
         )
         if self._send_zipkin_headers:
             headers.update(create_http_headers_for_new_span())
-        self._connection.send(
-            destination=topic, body=message.serialize(), headers=headers
-        )
-        self._logger.debug(f"Sent data to {topic}: {message}")
+        _timeout = self._send_timeout if timeout is ... else timeout
+        assert isinstance(_timeout, (int, float, type(None)))
+        start = time.time()
+        while True:
+            error = None
+            if self._connected:
+                try:
+                    self._connection.send(
+                        destination=topic, body=message.serialize(), headers=headers
+                    )
+                    self._logger.debug(f"Sent data to {topic}: {message}")
+                    return
+                except (OSError, stomp.exception.ConnectFailedException) as e:
+                    error = e
+            if _timeout is not None and time.time() - start >= _timeout:
+                exception = TimeoutError(f"Could not send message on topic {topic} within {_timeout} seconds.")
+                if error is not None:
+                    raise exception from error
+                else:
+                    raise exception
+            time.sleep(0.2)
 
     def _ensure_topic_exists(self, topic: str):
         if topic not in self._topics or topic not in self._hashes:
@@ -230,7 +253,12 @@ class Pigeon:
     def _handle_reconnect(self):
         self._connected = False
         self._logger.warning("Disconnected from broker. Attempting to reconnect...")
-        self.connect()
+        old_subscriptions = dict(self._callbacks)
+        self._callbacks = {}
+        time.sleep(1)
+        self.connect(announce=False)
+        for topic, callback in old_subscriptions.items():
+            self.subscribe(topic, callback, send_update=False)
 
     def _handle_message(self, message_frame: Frame):
         topic = message_frame.headers["subscription"]
@@ -304,6 +332,8 @@ class Pigeon:
                 messages. It may accept up to three arguments. In order, the
                 arguments are, the received message, the topic the message was
                 received on, and the message headers.
+            send_update (bool, optional): Send a notification of the subscription
+                through the broker.
 
         Raises:
             NoSuchTopicException: If the specified topic is not defined.
@@ -357,7 +387,7 @@ class Pigeon:
             self._logger.info("Disconnected from STOMP server.")
 
 
-class TEMCommsListener(stomp.ConnectionListener):
+class PigeonListener(stomp.ConnectionListener):
     def __init__(self, message_handler: Callable, disconnect_handler: Callable):
         self.message_handler = message_handler
         self.disconnect_handler = disconnect_handler

--- a/pigeon/client.py
+++ b/pigeon/client.py
@@ -167,8 +167,13 @@ class Pigeon:
                 )
                 break
             except stomp.exception.ConnectFailedException as e:
-                if self._connection_timeout is None or time.time() - start < self._connection_timeout:
-                    self._logger.error(f"Connection failed: {e}. Attempting to reconnect.")
+                if (
+                    self._connection_timeout is None
+                    or time.time() - start < self._connection_timeout
+                ):
+                    self._logger.error(
+                        f"Connection failed: {e}. Attempting to reconnect."
+                    )
                     time.sleep(1)
                 else:
                     raise stomp.exception.ConnectFailedException(
@@ -196,7 +201,9 @@ class Pigeon:
             exceptions.NoSuchTopicException: If the specified topic is not defined.
         """
         if not self._connected:
-            self._logger.warning(f"Not connected to broker! Unable to send message on topic {topic}.")
+            self._logger.warning(
+                f"Not connected to broker! Unable to send message on topic {topic}."
+            )
             return
         self._ensure_topic_exists(topic)
         serialized_data = self._topics[topic](**data).serialize()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = {file = ["requirements.txt"]}
 [project.optional-dependencies]
 test = [
   "pytest",
-  "pytest-mock"
+  "pytest-mock",
+  "pytest-timeout",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,6 +5,8 @@ from pigeon.client import Pigeon
 from pigeon.exceptions import NoSuchTopicException
 from pigeon import BaseMessage
 from pigeon.messages import core_topics
+import time
+from math import floor
 
 
 class MockMessage(BaseMessage):
@@ -27,6 +29,7 @@ def pigeon_client():
         yield client
 
 
+@pytest.mark.parametrize("announce", [True, False])
 @pytest.mark.parametrize(
     "username, password, expected_log",
     [
@@ -35,7 +38,7 @@ def pigeon_client():
     ],
     ids=["no-auth", "with-auth"],
 )
-def test_connect(pigeon_client, username, password, expected_log):
+def test_connect(pigeon_client, username, password, expected_log, announce):
     # Arrange
     pigeon_client._connection.connect = MagicMock()
     pigeon_client.subscribe = MagicMock()
@@ -44,7 +47,7 @@ def test_connect(pigeon_client, username, password, expected_log):
     assert not pigeon_client._connected
 
     # Act
-    pigeon_client.connect(username=username, password=password)
+    pigeon_client.connect(username=username, password=password, announce=announce)
 
     # Assert
     pigeon_client._connection.connect.assert_called_with(
@@ -54,7 +57,10 @@ def test_connect(pigeon_client, username, password, expected_log):
     pigeon_client.subscribe.assert_called_with(
         "&_request_state", pigeon_client._update_state
     )
-    pigeon_client._announce.assert_called()
+    if announce:
+        pigeon_client._announce.assert_called()
+    else:
+        pigeon_client._announce.assert_not_called()
 
     assert pigeon_client._connected
 
@@ -132,6 +138,32 @@ def test_send_no_such_topic(pigeon_client, topic, data):
         pigeon_client.send(topic, **data)
 
 
+@pytest.mark.timeout(2)
+@pytest.mark.parametrize("class_timeout, method_timeout, timeout", [(0, ..., 0), (0.5, ..., 0.5), (0, 0.3, 0.3), (None, 0.7, 0.7)])
+@pytest.mark.parametrize("reason", ["connected", OSError, ConnectFailedException])
+def test_send_timeout(mocker, pigeon_client, class_timeout, method_timeout, timeout, reason):
+    client = Pigeon(
+        "test",
+        host="localhost",
+        port=61613,
+        logger=mocker.MagicMock(),
+        load_topics=False,
+        connection_timeout=0.5,
+        send_timeout=class_timeout)
+    client._connected = reason != "connected"
+    client._ensure_topic_exists = mocker.MagicMock()
+    client._connection = mocker.MagicMock()
+    client.register_topic("some_topic", MockMessage)
+    if not isinstance(reason, str) and issubclass(reason, Exception):
+        client._connection.send.side_effect = reason
+    start = time.time()
+    with pytest.raises(TimeoutError):
+        client.send("some_topic", timeout=method_timeout, field1="data")
+    assert abs(time.time() - start - timeout) < 0.2
+
+
+
+@pytest.mark.parametrize("update_state", [True, False])
 @pytest.mark.parametrize(
     "topic, callback_name, expected_log",
     [
@@ -139,7 +171,7 @@ def test_send_no_such_topic(pigeon_client, topic, data):
     ],
     ids=["subscribe-new-topic"],
 )
-def test_subscribe(pigeon_client, topic, callback_name, expected_log):
+def test_subscribe(pigeon_client, topic, callback_name, expected_log, update_state):
     # Arrange
     pigeon_client._topics[topic] = MockMessage
     callback = MagicMock(__name__=callback_name)
@@ -147,13 +179,16 @@ def test_subscribe(pigeon_client, topic, callback_name, expected_log):
     pigeon_client._update_state = MagicMock()
 
     # Act
-    pigeon_client.subscribe(topic, callback)
+    pigeon_client.subscribe(topic, callback, update_state)
 
     # Assert
     assert pigeon_client._callbacks[topic] == callback
     pigeon_client._connection.subscribe.assert_called_with(destination=topic, id=topic)
     pigeon_client._logger.info.assert_called_with(expected_log.format(callback))
-    pigeon_client._update_state.assert_called()
+    if update_state:
+        pigeon_client._update_state.assert_called()
+    else:
+        pigeon_client._update_state.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -175,6 +210,7 @@ def test_subscribe_no_such_topic(pigeon_client, topic):
 def test_subscribe_all(pigeon_client, mocker):
     pigeon_client._connection = mocker.MagicMock()
     pigeon_client.subscribe = mocker.MagicMock()
+    pigeon_client._update_state = mocker.MagicMock()
 
     callback = mocker.MagicMock()
 
@@ -183,11 +219,13 @@ def test_subscribe_all(pigeon_client, mocker):
     assert len(pigeon_client.subscribe.mock_calls) == 2
     pigeon_client.subscribe.assert_any_call("topic1", callback, send_update=False)
     pigeon_client.subscribe.assert_any_call("topic2", callback, send_update=False)
+    pigeon_client._update_state.assert_called_once()
 
 
 def test_subscribe_all_with_core(pigeon_client, mocker):
     pigeon_client._connection = mocker.MagicMock()
     pigeon_client.subscribe = mocker.MagicMock()
+    pigeon_client._update_state = mocker.MagicMock()
 
     callback = mocker.MagicMock()
 
@@ -202,6 +240,7 @@ def test_subscribe_all_with_core(pigeon_client, mocker):
     pigeon_client.subscribe.assert_any_call(
         "&_update_state", callback, send_update=False
     )
+    pigeon_client._update_state.assert_called_once()
 
 
 def test_subscribe_all_no_topics(pigeon_client, mocker):
@@ -214,8 +253,37 @@ def test_subscribe_all_no_topics(pigeon_client, mocker):
     callback = mocker.MagicMock()
 
     pigeon_client.subscribe_all(callback)
-
     pigeon_client._logger.warning.assert_called_once()
+
+
+def test_handle_reconnect(pigeon_client, mocker):
+    pigeon_client._connected = True
+
+    pigeon_client.register_topic("topic3", MockMessage)
+    pigeon_client.register_topic("topic4", MockMessage)
+
+    topic2_cb = mocker.MagicMock()
+    topic3_cb = mocker.MagicMock()
+
+    pigeon_client.connect = mocker.MagicMock()
+    pigeon_client._connection = mocker.MagicMock()
+
+    pigeon_client.subscribe("topic2", topic2_cb)
+    pigeon_client.subscribe("topic3", topic3_cb)
+
+    pigeon_client.subscribe = mocker.MagicMock()
+
+
+    pigeon_client._handle_reconnect()
+
+    assert not pigeon_client._connected
+    assert pigeon_client._callbacks == {}
+    assert len(pigeon_client.subscribe.mock_calls) == 2
+
+    pigeon_client.connect.assert_called_once_with(announce=False)
+    pigeon_client.subscribe.assert_any_call("topic2", topic2_cb, send_update=False)
+    pigeon_client.subscribe.assert_any_call("topic3", topic3_cb, send_update=False)
+    pigeon_client._logger.warning.assert_called_once_with("Disconnected from broker. Attempting to reconnect...")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -78,9 +78,7 @@ def test_connect_failure(pigeon_client, username, password):
     with pytest.raises(
         ConnectFailedException, match="Could not connect to server: Connection failed"
     ):
-        pigeon_client.connect(
-            username=username, password=password
-        )
+        pigeon_client.connect(username=username, password=password)
 
     # Assert the logger was called the same number of times as the retry limit
     assert pigeon_client._logger.error.call_count == 1

--- a/tests/test_message_handler.py
+++ b/tests/test_message_handler.py
@@ -34,7 +34,7 @@ def test_one_arg(pigeon_client):
     pigeon_client._connection = MagicMock()
     pigeon_client._topics["test.msg"] = mock_message
     pigeon_client._hashes["test.msg"] = "abcd"
-    pigeon_client.subscribe("test.msg", callback)
+    pigeon_client.subscribe("test.msg", callback, False)
 
     pigeon_client._handle_message(mock_stomp_message)
 
@@ -56,7 +56,7 @@ def test_two_args(pigeon_client):
     pigeon_client._connection = MagicMock()
     pigeon_client._topics["test.msg"] = mock_message
     pigeon_client._hashes["test.msg"] = "abcde"
-    pigeon_client.subscribe("test.msg", callback)
+    pigeon_client.subscribe("test.msg", callback, False)
 
     pigeon_client._handle_message(mock_stomp_message)
 
@@ -79,7 +79,7 @@ def test_three_args(pigeon_client):
     pigeon_client._connection = MagicMock()
     pigeon_client._topics["test.msg"] = mock_message
     pigeon_client._hashes["test.msg"] = "123abc"
-    pigeon_client.subscribe("test.msg", callback)
+    pigeon_client.subscribe("test.msg", callback, False)
 
     pigeon_client._handle_message(mock_stomp_message)
 
@@ -103,7 +103,7 @@ def test_var_args(pigeon_client):
     pigeon_client._connection = MagicMock()
     pigeon_client._topics["test.msg"] = mock_message
     pigeon_client._hashes["test.msg"] = "xyz987"
-    pigeon_client.subscribe("test.msg", callback)
+    pigeon_client.subscribe("test.msg", callback, False)
 
     pigeon_client._handle_message(mock_stomp_message)
 
@@ -168,7 +168,7 @@ def test_bad_signature(pigeon_client):
 
     pigeon_client._topics["test"] = MagicMock()
     pigeon_client._hashes["test"] = "lmnop"
-    pigeon_client.subscribe("test", callback)
+    pigeon_client.subscribe("test", callback, False)
     pigeon_client._handle_message(mock_message)
 
     pigeon_client._logger.warning.assert_called_with(
@@ -182,7 +182,7 @@ def test_callback_exception(pigeon_client):
     pigeon_client._topics["test"] = MagicMock()
     pigeon_client._hashes["test"] = "987654321"
     pigeon_client.subscribe(
-        "test", MagicMock(side_effect=RecursionError("This is a test error."))
+        "test", MagicMock(side_effect=RecursionError("This is a test error.")), False
     )
     pigeon_client._handle_message(mock_message)
 

--- a/tests/test_zipkin.py
+++ b/tests/test_zipkin.py
@@ -79,6 +79,7 @@ def test_send_zipkin(mocker, use_zipkin, zipkin_headers, message_headers):
     client._name = "a name"
     client._hostname = "hosty mchostface"
     client._pid = 1
+    client._connected = True
 
     client.register_topic("test", Msg)
     client._hashes["test"] = "abc123"

--- a/tests/test_zipkin.py
+++ b/tests/test_zipkin.py
@@ -169,7 +169,7 @@ def test_receive_zipkin(mocker, use_zipkin, message_headers, span_created):
     client._hashes["test"] = "abc123"
 
     callback = mocker.MagicMock()
-    client.subscribe("test", callback)
+    client.subscribe("test", callback, False)
 
     msg = Frame("", body='{"value":"something"}', headers=message_headers)
 


### PR DESCRIPTION
Currently, programs using this library quickly dies if the message broker goes offline. This PR fixes #16 by implementing a method to reconnect after the connection is lost. Furthermore, a timeout option has been added to the `send` method allowing the main loop of a program to simply wait until communication with the broker is reestablished.

As these changes are already significant enough to warrant a major version release, sensible default values for the reconnect and send timeouts should be decided upon.